### PR TITLE
ssl_version update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 setup(
     name = "1and1",
     packages = ['oneandone'],
-    version = "1.6.0",
+    version = "1.7.3",
     author = "Tyler Burkhardt (stackpoint.io)",
     author_email = "tyler@stackpointcloud.com",
     description = ("1&1 API Client Library for Python"),


### PR DESCRIPTION
 Added back and updated the way that ssl_version data is set in MyAdapter class to fix the errors latest ansible version was reporting. The absence of ssl_version data was making ansible to throw errors.